### PR TITLE
Imprimir Associados

### DIFF
--- a/src/components/ConsultaAssociados/ConsultAssociate.js
+++ b/src/components/ConsultaAssociados/ConsultAssociate.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import Modal from '@material-ui/core/Modal';
 import { useTheme } from '@mui/material/styles';
 import Table from '@mui/material/Table';
-import { Link } from 'react-router-dom';
+import { Link, useHistory } from 'react-router-dom';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
@@ -120,6 +120,7 @@ function ConsultaAssociados({
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(print ? -1 : 10);
   const [open, setOpen] = useState(false);
+  const history = useHistory();
 
   const matches = useMediaQuery('(max-width:930px)');
   const matchesFont90 = useMediaQuery('(max-width:930px)');
@@ -127,7 +128,10 @@ function ConsultaAssociados({
   const matchesFont400px = useMediaQuery('(max-width:400px)');
 
   const handleWindowOpen = () => {
-    window.open('/imprimir-associados');
+    history.push({
+      pathname: '/imprimir-associados',
+      state: data,
+    });
   };
 
   const footerProps = {

--- a/src/components/ConsultaAssociados/ConsultAssociate.js
+++ b/src/components/ConsultaAssociados/ConsultAssociate.js
@@ -126,14 +126,8 @@ function ConsultaAssociados({
   const matchesFont400px = useMediaQuery('(max-width:400px)');
 
   const imprimirAssociados = () => {
-    if (sequentialId) {
-      data.forEach((associate) => {
-        delete associate._id;
-      });
-    }
     sessionStorage.setItem('associadosToPrint', JSON.stringify(data));
     sessionStorage.setItem('titlesToPrint', JSON.stringify(titles));
-
     window.open('/imprimir-associados');
   };
 

--- a/src/components/ConsultaAssociados/ConsultAssociate.js
+++ b/src/components/ConsultaAssociados/ConsultAssociate.js
@@ -8,7 +8,7 @@ import PropTypes from 'prop-types';
 import Modal from '@material-ui/core/Modal';
 import { useTheme } from '@mui/material/styles';
 import Table from '@mui/material/Table';
-import { Link, useHistory } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 import TableBody from '@mui/material/TableBody';
 import TableCell from '@mui/material/TableCell';
 import TableContainer from '@mui/material/TableContainer';
@@ -120,7 +120,6 @@ function ConsultaAssociados({
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(print ? -1 : 10);
   const [open, setOpen] = useState(false);
-  const history = useHistory();
 
   const matches = useMediaQuery('(max-width:930px)');
   const matchesFont90 = useMediaQuery('(max-width:930px)');
@@ -128,10 +127,8 @@ function ConsultaAssociados({
   const matchesFont400px = useMediaQuery('(max-width:400px)');
 
   const handleWindowOpen = () => {
-    history.push({
-      pathname: '/imprimir-associados',
-      state: data,
-    });
+    sessionStorage.setItem('associadosToPrint', JSON.stringify(data));
+    window.open('/imprimir-associados');
   };
 
   const footerProps = {

--- a/src/components/ConsultaAssociados/ConsultAssociate.js
+++ b/src/components/ConsultaAssociados/ConsultAssociate.js
@@ -104,7 +104,6 @@ TablePaginationActions.propTypes = {
 function ConsultaAssociados({
   titles,
   rows,
-  id,
   order,
   edit,
   search,
@@ -126,22 +125,13 @@ function ConsultaAssociados({
   const matchesFont85 = useMediaQuery('(max-width:680px)');
   const matchesFont400px = useMediaQuery('(max-width:400px)');
 
-  const handleWindowOpen = () => {
-    let toPrint = [];
-    if (sequentialId != null) {
-      let i = 0;
-      data.forEach((associado) => {
-        const { name, cpf, status } = associado;
-        const codigo = sequentialId[i];
-        toPrint.push({
-          codigo, name, cpf, status,
-        });
-        i += 1;
+  const imprimirAssociados = () => {
+    if (sequentialId) {
+      data.forEach((associate) => {
+        delete associate._id;
       });
-    } else {
-      toPrint = data;
     }
-    sessionStorage.setItem('associadosToPrint', JSON.stringify(toPrint));
+    sessionStorage.setItem('associadosToPrint', JSON.stringify(data));
     sessionStorage.setItem('titlesToPrint', JSON.stringify(titles));
 
     window.open('/imprimir-associados');
@@ -306,7 +296,7 @@ function ConsultaAssociados({
             && (rowsPerPage > 0
               ? data?.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
               : data)
-              ?.map((row, index) => (
+              ?.map((row) => (
                 <TableRow>
                   {order ? (
                     <TableCell {...cellFontProps} align="center">
@@ -314,7 +304,7 @@ function ConsultaAssociados({
                     </TableCell>
                   ) : search ? (
                     <TableCell {...cellFontProps} align="center">
-                      <IconButton color="primary" aria-label="Search" onClick={(e) => redirect(e, id[index + (page * 10)])}>
+                      <IconButton color="primary" aria-label="Search" onClick={(e) => redirect(e, [row._id])}>
                         <SearchIcon />
                       </IconButton>
                     </TableCell>
@@ -335,30 +325,36 @@ function ConsultaAssociados({
                     <TableCell {...cellFontProps} align="center">
                       <FindInPageIcon aria-label="findFile" />
                     </TableCell>
-                  ) : (
-                    null
-                  )}
-                  {sequentialId
-                    && (
-                      <TableCell {...cellFontProps}>
-                        <Link
-                          style={{ textDecoration: 'none', display: 'flex', justifyContent: 'center' }}
-                          to={{
-                            pathname: '/editar-associados',
-                            state: {
-                              id: id[index + (page * 10)],
-                            },
-                          }}
-                        >
-                          {sequentialId[index + (page * 10)]}
-                        </Link>
-                      </TableCell>
-                    )}
-                  {Object.values(row)?.map((dado) => (
+                  ) : (null)}
+
+                  {sequentialId ? (
                     <TableCell {...cellFontProps}>
-                      {dado}
+                      <Link
+                        style={{ textDecoration: 'none', display: 'flex', justifyContent: 'center' }}
+                        to={{
+                          pathname: '/editar-associados',
+                          state: {
+                            id: row._id,
+                          },
+                        }}
+                      >
+                        {row.seqId}
+                      </Link>
                     </TableCell>
-                  ))}
+                  ) : (null)}
+
+                  {sequentialId ? (
+                    Object.values(row)?.slice(2).map((dado) => (
+                      <TableCell {...cellFontProps}>
+                        {dado}
+                      </TableCell>
+                    ))) : (
+                    Object.values(row)?.slice(1).map((dado) => (
+                      <TableCell {...cellFontProps}>
+                        {dado}
+                      </TableCell>
+                    )))}
+
                 </TableRow>
               ))}
           {emptyRows > 0 && (
@@ -468,7 +464,7 @@ function ConsultaAssociados({
                 sx={{
                   marginBottom: '5px',
                 }}
-                onClick={handleWindowOpen}
+                onClick={imprimirAssociados}
               >
                 Imprimir
               </Button>

--- a/src/components/ConsultaAssociados/ConsultAssociate.js
+++ b/src/components/ConsultaAssociados/ConsultAssociate.js
@@ -289,63 +289,65 @@ function ConsultaAssociados({
           </TableRow>
         </TableHead>
         <TableBody>
-          {!loading && data
-            ?.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
-            ?.map((row, index) => (
-              <TableRow>
-                {order ? (
-                  <TableCell {...cellFontProps} align="center">
-                    {data.findIndex((obj) => obj._id === row._id) + 1}
-                  </TableCell>
-                ) : search ? (
-                  <TableCell {...cellFontProps} align="center">
-                    <IconButton color="primary" aria-label="Search" onClick={(e) => redirect(e, id[index + (page * 10)])}>
-                      <SearchIcon />
-                    </IconButton>
-                  </TableCell>
-                ) : edit ? (
-                  <TableCell {...cellFontProps} align="center">
-                    <IconButton aria-label="delete">
-                      <DeleteIcon />
-                      {/* TODO Substituir o modal de deletar no lugar do DeleteIcon, passando row._id e tipo do delete.
-                      Há um modal implementado de forma parecida na pagina de produtos do lojista no pet system */}
-                    </IconButton>
-                    <IconButton color="primary" aria-label="Edit">
-                      <EditIcon />
-                      {/* TODO Substituir o modal de pesquisa no lugar do editIcon, passando row._id e tipo da edição.
-                      Há um modal implementado de forma parecida na pagina de produtos do lojista no pet system */}
-                    </IconButton>
-                  </TableCell>
-                ) : searchFile ? (
-                  <TableCell {...cellFontProps} align="center">
-                    <FindInPageIcon aria-label="findFile" />
-                  </TableCell>
-                ) : (
-                  null
-                )}
-                {sequentialId
-                  && (
-                    <TableCell {...cellFontProps}>
-                      <Link
-                        style={{ textDecoration: 'none', display: 'flex', justifyContent: 'center' }}
-                        to={{
-                          pathname: '/editar-associados',
-                          state: {
-                            id: id[index + (page * 10)],
-                          },
-                        }}
-                      >
-                        {sequentialId[index + (page * 10)]}
-                      </Link>
+          {!loading
+            && (rowsPerPage > 0
+              ? data?.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+              : data)
+              ?.map((row, index) => (
+                <TableRow>
+                  {order ? (
+                    <TableCell {...cellFontProps} align="center">
+                      {data.findIndex((obj) => obj._id === row._id) + 1}
                     </TableCell>
+                  ) : search ? (
+                    <TableCell {...cellFontProps} align="center">
+                      <IconButton color="primary" aria-label="Search" onClick={(e) => redirect(e, id[index + (page * 10)])}>
+                        <SearchIcon />
+                      </IconButton>
+                    </TableCell>
+                  ) : edit ? (
+                    <TableCell {...cellFontProps} align="center">
+                      <IconButton aria-label="delete">
+                        <DeleteIcon />
+                        {/* TODO Substituir o modal de deletar no lugar do DeleteIcon, passando row._id e tipo do delete.
+                      Há um modal implementado de forma parecida na pagina de produtos do lojista no pet system */}
+                      </IconButton>
+                      <IconButton color="primary" aria-label="Edit">
+                        <EditIcon />
+                        {/* TODO Substituir o modal de pesquisa no lugar do editIcon, passando row._id e tipo da edição.
+                      Há um modal implementado de forma parecida na pagina de produtos do lojista no pet system */}
+                      </IconButton>
+                    </TableCell>
+                  ) : searchFile ? (
+                    <TableCell {...cellFontProps} align="center">
+                      <FindInPageIcon aria-label="findFile" />
+                    </TableCell>
+                  ) : (
+                    null
                   )}
-                {Object.values(row)?.map((dado) => (
-                  <TableCell {...cellFontProps}>
-                    {dado}
-                  </TableCell>
-                ))}
-              </TableRow>
-            ))}
+                  {sequentialId
+                    && (
+                      <TableCell {...cellFontProps}>
+                        <Link
+                          style={{ textDecoration: 'none', display: 'flex', justifyContent: 'center' }}
+                          to={{
+                            pathname: '/editar-associados',
+                            state: {
+                              id: id[index + (page * 10)],
+                            },
+                          }}
+                        >
+                          {sequentialId[index + (page * 10)]}
+                        </Link>
+                      </TableCell>
+                    )}
+                  {Object.values(row)?.map((dado) => (
+                    <TableCell {...cellFontProps}>
+                      {dado}
+                    </TableCell>
+                  ))}
+                </TableRow>
+              ))}
           {emptyRows > 0 && (
             <TableRow style={{ height: 53 * emptyRows }}>
               <TableCell

--- a/src/components/ConsultaAssociados/ConsultAssociate.js
+++ b/src/components/ConsultaAssociados/ConsultAssociate.js
@@ -127,7 +127,23 @@ function ConsultaAssociados({
   const matchesFont400px = useMediaQuery('(max-width:400px)');
 
   const handleWindowOpen = () => {
-    sessionStorage.setItem('associadosToPrint', JSON.stringify(data));
+    let toPrint = [];
+    if (sequentialId != null) {
+      let i = 0;
+      data.forEach((associado) => {
+        const { name, cpf, status } = associado;
+        const codigo = sequentialId[i];
+        toPrint.push({
+          codigo, name, cpf, status,
+        });
+        i += 1;
+      });
+    } else {
+      toPrint = data;
+    }
+    sessionStorage.setItem('associadosToPrint', JSON.stringify(toPrint));
+    sessionStorage.setItem('titlesToPrint', JSON.stringify(titles));
+
     window.open('/imprimir-associados');
   };
 

--- a/src/components/SearchAdvanced/SearchAdvanced.js
+++ b/src/components/SearchAdvanced/SearchAdvanced.js
@@ -32,9 +32,9 @@ function SearchAdvanced({
     };
   }
 
-  function returnData(seqId, _id, name, cpf, status) {
+  function returnData(_id, seqId, name, cpf, status) {
     return {
-      seqId, _id, name, cpf, status,
+      _id, seqId, name, cpf, status,
     };
   }
 
@@ -60,7 +60,7 @@ function SearchAdvanced({
   if (dados) {
     auxFilterType = dados?.filter(((item) => item.judicial_section?.includes(type)));
     auxFilterType.forEach((object) => {
-      filterType.push(returnData(object?.sequential_Id, object?._id, object.name, object.cpf, object.status));
+      filterType.push(returnData(object?._id, object?.sequential_Id, object.name, object.cpf, object.status));
     });
   }
 

--- a/src/components/SearchAdvanced/SearchAdvanced.js
+++ b/src/components/SearchAdvanced/SearchAdvanced.js
@@ -26,15 +26,15 @@ function SearchAdvanced({
     return str.replace(/[^a-z0-9]/gi, '');
   }
 
-  function createData(name, cpf, status, allocation, acting, email) {
+  function createData(_id, name, cpf, status, allocation, acting, email) {
     return {
-      name, cpf, status, allocation, acting, email,
+      _id, name, cpf, status, allocation, acting, email,
     };
   }
 
-  function returnData(name, cpf, status) {
+  function returnData(seqId, _id, name, cpf, status) {
     return {
-      name, cpf, status,
+      seqId, _id, name, cpf, status,
     };
   }
 
@@ -46,6 +46,7 @@ function SearchAdvanced({
     auxFilterType = dataFilter?.filter(((item) => item.judicial_section?.includes(type)));
     auxFilterType.forEach((object) => {
       filterType.push(createData(
+        object._id,
         object.name,
         object.cell_phone_number,
         object.status,
@@ -59,7 +60,7 @@ function SearchAdvanced({
   if (dados) {
     auxFilterType = dados?.filter(((item) => item.judicial_section?.includes(type)));
     auxFilterType.forEach((object) => {
-      filterType.push(returnData(object.name, object.cpf, object.status));
+      filterType.push(returnData(object?.sequential_Id, object?._id, object.name, object.cpf, object.status));
     });
   }
 

--- a/src/components/dashboard/dashboardComponent.js
+++ b/src/components/dashboard/dashboardComponent.js
@@ -45,7 +45,7 @@ import RemoveAccountModal from '../RemoveModal/RemoveAccountModal';
 import RemoveActionModal from '../RemoveModal/RemoveActionModal';
 import EditActionModal from '../EditModal/EditActionModal';
 import * as managerService from '../../services/manager/managerService';
-import SetFileNameArchive from '../SetFileNameArchive/SetFileNameArchive';
+import SetFileNameArchive from '../SetFileNameArchive/setFileNameArchive';
 import ExcludeModelModal from '../DeleteModel/excludeModelModal';
 import EditModel from '../EditModal/EditModelsModal';
 import EditMinutesModal from '../EditModal/EditAtasModal';

--- a/src/components/dashboard/dashboardComponent.js
+++ b/src/components/dashboard/dashboardComponent.js
@@ -45,7 +45,7 @@ import RemoveAccountModal from '../RemoveModal/RemoveAccountModal';
 import RemoveActionModal from '../RemoveModal/RemoveActionModal';
 import EditActionModal from '../EditModal/EditActionModal';
 import * as managerService from '../../services/manager/managerService';
-import SetFileNameArchive from '../SetFileNameArchive/setFileNameArchive';
+import SetFileNameArchive from '../SetFileNameArchive/SetFileNameArchive';
 import ExcludeModelModal from '../DeleteModel/excludeModelModal';
 import EditModel from '../EditModal/EditModelsModal';
 import EditMinutesModal from '../EditModal/EditAtasModal';

--- a/src/components/getAllAssociatesForConsult/getAllAssociatesForConsult.js
+++ b/src/components/getAllAssociatesForConsult/getAllAssociatesForConsult.js
@@ -31,8 +31,8 @@ async function getAllAssociatesForConsult(setId, setAllAssociates, setLoading, s
   try {
     const allAssociates = await managerService.getAssociates();
     allAssociates.sort(compare);
-
-    allAssociates.filter((user) => user.type.toLowerCase() !== 'administrador').filter((associate) => associate.status === 'A').forEach((object) => {
+    const activeAssociates = allAssociates.filter((user) => user.type.toLowerCase() !== 'administrador').filter((associate) => associate.status === 'A');
+    activeAssociates.forEach((object) => {
       associateId.push(object._id);
       auxAssociate.push(createData(
         object.name,
@@ -42,7 +42,7 @@ async function getAllAssociatesForConsult(setId, setAllAssociates, setLoading, s
         object.acting,
         object.email,
       ));
-      setDataFilter(allAssociates);
+      setDataFilter(activeAssociates);
     });
 
     setId(associateId);

--- a/src/components/getAllAssociatesForConsult/getAllAssociatesForConsult.js
+++ b/src/components/getAllAssociatesForConsult/getAllAssociatesForConsult.js
@@ -46,7 +46,6 @@ async function getAllAssociatesForConsult(setId, setAllAssociates, setLoading, s
     });
 
     setId(associateId);
-    console.log(associateId);
     setAllAssociates(auxAssociate);
     setLoading(false);
   } catch (error) {

--- a/src/components/getAllAssociatesForConsult/getAllAssociatesForConsult.js
+++ b/src/components/getAllAssociatesForConsult/getAllAssociatesForConsult.js
@@ -11,9 +11,9 @@ const routingFunction = (param) => {
   });
 };
 
-function createData(name, cellPhoneNumber, status, allocation, acting, email) {
+function createData(_id, name, cellPhoneNumber, status, allocation, acting, email) {
   return {
-    name, cellPhoneNumber, status, allocation, acting, email,
+    _id, name, cellPhoneNumber, status, allocation, acting, email,
   };
 }
 
@@ -24,17 +24,16 @@ function compare(a, b) {
   return x === y ? 0 : x > y ? 1 : -1;
 }
 
-async function getAllAssociatesForConsult(setId, setAllAssociates, setLoading, setDataFilter) {
+async function getAllAssociatesForConsult(setAllAssociates, setLoading, setDataFilter) {
   setLoading(true);
   const auxAssociate = [];
-  const associateId = [];
   try {
     const allAssociates = await managerService.getAssociates();
     allAssociates.sort(compare);
     const activeAssociates = allAssociates.filter((user) => user.type.toLowerCase() !== 'administrador').filter((associate) => associate.status === 'A');
     activeAssociates.forEach((object) => {
-      associateId.push(object._id);
       auxAssociate.push(createData(
+        object._id,
         object.name,
         object.cell_phone_number,
         object.status,
@@ -44,8 +43,6 @@ async function getAllAssociatesForConsult(setId, setAllAssociates, setLoading, s
       ));
       setDataFilter(activeAssociates);
     });
-
-    setId(associateId);
     setAllAssociates(auxAssociate);
     setLoading(false);
   } catch (error) {

--- a/src/components/getAllAssociatesForConsult/getAllAssociatesForConsult.js
+++ b/src/components/getAllAssociatesForConsult/getAllAssociatesForConsult.js
@@ -46,6 +46,7 @@ async function getAllAssociatesForConsult(setId, setAllAssociates, setLoading, s
     });
 
     setId(associateId);
+    console.log(associateId);
     setAllAssociates(auxAssociate);
     setLoading(false);
   } catch (error) {

--- a/src/pages/AdmRegistros/AdmRegistros.js
+++ b/src/pages/AdmRegistros/AdmRegistros.js
@@ -19,7 +19,7 @@ function AdmRegistros() {
     try {
       const allAssociates = await managerService.getAssociates();
       allAssociates.forEach(({
-        sequential_Id: seqId, _id, name, cpf, status, // Eslint exigiu
+        sequential_Id: seqId, _id, name, cpf, status,
       }) => {
         auxAssociate.push({
           seqId, _id, name, cpf, status,

--- a/src/pages/AdmRegistros/AdmRegistros.js
+++ b/src/pages/AdmRegistros/AdmRegistros.js
@@ -10,29 +10,24 @@ toast.configure();
 function AdmRegistros() {
   const [associates, setAllAssociates] = useState([]);
   const [dados, setDados] = useState([]);
-  const [sequentialId, setSequentialId] = useState([]);
-  const [id, setId] = useState([]);
   const [loading, setLoading] = useState(false);
+  const sequentialId = true;
 
   async function getAllAssociates() {
     setLoading(true);
     const auxAssociate = [];
-    const associateCode = [];
-    const associateId = [];
     try {
       const allAssociates = await managerService.getAssociates();
       allAssociates.forEach(({
         sequential_Id: seqId, _id, name, cpf, status, // Eslint exigiu
       }) => {
-        associateCode.push(seqId);
-        associateId.push(_id);
-        auxAssociate.push({ name, cpf, status });
+        auxAssociate.push({
+          seqId, _id, name, cpf, status,
+        });
       });
       setDados(allAssociates);
       auxAssociate.sort();
-      setId(associateId);
       setAllAssociates(auxAssociate);
-      setSequentialId(associateCode);
       setLoading(false);
     } catch (error) {
       // eslint-disable-next-line no-console
@@ -61,7 +56,6 @@ function AdmRegistros() {
       </div>
       <div className="line-table-registers" />
       <TableComponent
-        id={id}
         sequentialId={sequentialId}
         dados={dados}
         rows={associates}

--- a/src/pages/AdmRegistros/AdmRegistros.js
+++ b/src/pages/AdmRegistros/AdmRegistros.js
@@ -22,7 +22,7 @@ function AdmRegistros() {
         sequential_Id: seqId, _id, name, cpf, status, // Eslint exigiu
       }) => {
         auxAssociate.push({
-          seqId, _id, name, cpf, status,
+          _id, seqId, name, cpf, status,
         });
       });
       setDados(allAssociates);

--- a/src/pages/ConsultaAssociados/ConsultaAssociados.js
+++ b/src/pages/ConsultaAssociados/ConsultaAssociados.js
@@ -17,11 +17,10 @@ const titles = [
 function ConsultaAssociados() {
   const [associates, setAllAssociates] = useState([]);
   const [dataFilter, setDataFilter] = useState([]);
-  const [id, setId] = useState([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    getAllAssociatesForConsult(setId, setAllAssociates, setLoading, setDataFilter);
+    getAllAssociatesForConsult(setAllAssociates, setLoading, setDataFilter);
   }, []);
 
   return (
@@ -36,7 +35,6 @@ function ConsultaAssociados() {
       </div>
       <div className="containerConsultAssociate">
         <TableComponent
-          id={id}
           rows={associates}
           titles={titles}
           print={false}

--- a/src/pages/ImprimirAssociados/ImprimirAssociados.js
+++ b/src/pages/ImprimirAssociados/ImprimirAssociados.js
@@ -38,8 +38,8 @@ const titles = [
   'Email',
 ];
 
-function Imprimir(data) {
-  const { location } = data;
+function Imprimir() {
+  const associados = JSON.parse(sessionStorage.associadosToPrint);
   const [printAssociados, setPrintAssociados] = useState({ print: false, resolve: undefined });
 
   const handleWindowClose = () => {
@@ -87,7 +87,7 @@ function Imprimir(data) {
       {printAssociados?.print ? (
         <div className="print-consult-associates-forms">
           <ComponentToPrint
-            rows={location.state}
+            rows={associados}
             titles={titles}
             printAssociados={printAssociados}
             ref={tableAssociates}
@@ -95,7 +95,7 @@ function Imprimir(data) {
         </div>
       ) : (
         <div className="print-associates-table">
-          <ComponentToPrint rows={location.state} titles={titles} ref={tableAssociates} />
+          <ComponentToPrint rows={associados} titles={titles} ref={tableAssociates} />
         </div>
       )}
     </div>

--- a/src/pages/ImprimirAssociados/ImprimirAssociados.js
+++ b/src/pages/ImprimirAssociados/ImprimirAssociados.js
@@ -43,6 +43,7 @@ const titles = [
 
 function Imprimir() {
   const [associates, setAllAssociates] = useState([]);
+  const [dataFilter, setDataFilter] = useState([]);
   const [id, setId] = useState([]);
   const [loading, setLoading] = useState(true);
   const [printAssociados, setPrintAssociados] = useState({ print: false, resolve: undefined });
@@ -70,7 +71,7 @@ function Imprimir() {
   });
 
   useEffect(() => {
-    getAllAssociatesForConsult(setId, setAllAssociates, setLoading);
+    getAllAssociatesForConsult(setId, setAllAssociates, setLoading, setDataFilter);
   }, []);
 
   return (

--- a/src/pages/ImprimirAssociados/ImprimirAssociados.js
+++ b/src/pages/ImprimirAssociados/ImprimirAssociados.js
@@ -29,18 +29,11 @@ class ComponentToPrint extends React.Component {
   }
 }
 
-const titles = [
-  'Nome',
-  'Celular',
-  'Status',
-  'Lotação',
-  'Atuação',
-  'Email',
-];
-
 function Imprimir() {
+  const titles = JSON.parse(sessionStorage.titlesToPrint);
   const associados = JSON.parse(sessionStorage.associadosToPrint);
   const [printAssociados, setPrintAssociados] = useState({ print: false, resolve: undefined });
+  titles.shift();
 
   const handleWindowClose = () => {
     window.close();

--- a/src/pages/ImprimirAssociados/ImprimirAssociados.js
+++ b/src/pages/ImprimirAssociados/ImprimirAssociados.js
@@ -5,13 +5,11 @@ import PrintRoundedIcon from '@mui/icons-material/PrintRounded';
 import BackspaceIcon from '@mui/icons-material/Backspace';
 import { useReactToPrint } from 'react-to-print';
 import TableComponent from '../../components/ConsultaAssociados/ConsultAssociate';
-import getAllAssociatesForConsult from '../../components/getAllAssociatesForConsult/getAllAssociatesForConsult';
 import './ImprimirAssociate.css';
 
 // eslint-disable-next-line react/prefer-stateless-function
 class ComponentToPrint extends React.Component {
   render() {
-    const { id } = this.props;
     const { rows } = this.props;
     const { titles } = this.props;
     const { ref } = this.props;
@@ -20,7 +18,6 @@ class ComponentToPrint extends React.Component {
     return (
       <div>
         <TableComponent
-          id={id}
           rows={rows}
           titles={titles}
           printAssociados={printAssociados?.print}
@@ -41,12 +38,11 @@ const titles = [
   'Email',
 ];
 
-function Imprimir() {
-  const [associates, setAllAssociates] = useState([]);
-  const [dataFilter, setDataFilter] = useState([]);
-  const [id, setId] = useState([]);
-  const [loading, setLoading] = useState(true);
+function Imprimir(data) {
+  const { location } = data;
   const [printAssociados, setPrintAssociados] = useState({ print: false, resolve: undefined });
+
+  console.log(location.state);
 
   const handleWindowClose = () => {
     window.close();
@@ -69,10 +65,6 @@ function Imprimir() {
     content: () => tableAssociates?.current,
     onAfterPrint: () => setPrintAssociados({ print: false, resolve: undefined }),
   });
-
-  useEffect(() => {
-    getAllAssociatesForConsult(setId, setAllAssociates, setLoading, setDataFilter);
-  }, []);
 
   return (
     <div className="container-print-associates-page">
@@ -97,17 +89,15 @@ function Imprimir() {
       {printAssociados?.print ? (
         <div className="print-consult-associates-forms">
           <ComponentToPrint
-            id={id}
-            rows={associates}
+            rows={location.state}
             titles={titles}
             printAssociados={printAssociados}
             ref={tableAssociates}
-            loading={loading}
           />
         </div>
       ) : (
         <div className="print-associates-table">
-          <ComponentToPrint id={id} rows={associates} titles={titles} ref={tableAssociates} loading={loading} />
+          <ComponentToPrint rows={location.state} titles={titles} ref={tableAssociates} />
         </div>
       )}
     </div>

--- a/src/pages/ImprimirAssociados/ImprimirAssociados.js
+++ b/src/pages/ImprimirAssociados/ImprimirAssociados.js
@@ -71,7 +71,7 @@ function Imprimir() {
   });
 
   useEffect(() => {
-    getAllAssociatesForConsult(setId, setAllAssociates, setLoading);
+    getAllAssociatesForConsult(setId, setAllAssociates, setLoading, setDataFilter);
   }, []);
 
   return (

--- a/src/pages/ImprimirAssociados/ImprimirAssociados.js
+++ b/src/pages/ImprimirAssociados/ImprimirAssociados.js
@@ -42,8 +42,6 @@ function Imprimir(data) {
   const { location } = data;
   const [printAssociados, setPrintAssociados] = useState({ print: false, resolve: undefined });
 
-  console.log(location.state);
-
   const handleWindowClose = () => {
     window.close();
   };

--- a/src/pages/ImprimirAssociados/ImprimirAssociados.js
+++ b/src/pages/ImprimirAssociados/ImprimirAssociados.js
@@ -71,7 +71,7 @@ function Imprimir() {
   });
 
   useEffect(() => {
-    getAllAssociatesForConsult(setId, setAllAssociates, setLoading, setDataFilter);
+    getAllAssociatesForConsult(setId, setAllAssociates, setLoading);
   }, []);
 
   return (

--- a/src/pages/ImprimirAssociados/ImprimirAssociate.css
+++ b/src/pages/ImprimirAssociados/ImprimirAssociate.css
@@ -1,3 +1,8 @@
+.container-print-associates-page {
+  min-height: calc(100vh - 146px);
+  display: flex;
+  flex-direction: column;
+}
 
 .header-print-associates-icon {
   display: flex;
@@ -38,7 +43,7 @@
 }
 
 .print-consult-associates-forms {
-  table-layout:fixed;
-  width:100%;
+  table-layout: fixed;
+  width: 100%;
   overflow-x: unset;
 }

--- a/src/pages/ImprimirAtas/ImprimirAtas.js
+++ b/src/pages/ImprimirAtas/ImprimirAtas.js
@@ -1,5 +1,5 @@
 import React, {
-  useRef, useState, useEffect,
+  useRef, useEffect, useState,
 } from 'react';
 import PrintRoundedIcon from '@mui/icons-material/PrintRounded';
 import BackspaceIcon from '@mui/icons-material/Backspace';


### PR DESCRIPTION
Inicialmente, estava faltando um parametro na imprimir associados ao chamar a função que pegava todos os associados do back, e a logica de loop dela não estava totalmente funcional.

Quando solucionado, surgiu o problema que a pagina de consulta e imprimir não estavam relacionadas, e isso impedia que se aplicasse os filtros de pesquisa. Os associados já filtrados foram passados por state pelo history.push, para serem pegos pelo imprimir associados. 

Em resumo, a página de imprimir associados era uma cópia da consulta associados, houve uma limpeza de código.

FInalmente, ao imprimir, a ultima linha estava sendo omitida, e foi corrigido a partir da alteração da lógica para a situação em que deve-se imprimir todas as linhas.