### PR TITLE
[Menu Lateral] Lupa

### DIFF
--- a/src/components/dashboard/dashboardComponent.js
+++ b/src/components/dashboard/dashboardComponent.js
@@ -45,7 +45,7 @@ import RemoveAccountModal from '../RemoveModal/RemoveAccountModal';
 import RemoveActionModal from '../RemoveModal/RemoveActionModal';
 import EditActionModal from '../EditModal/EditActionModal';
 import * as managerService from '../../services/manager/managerService';
-import SetFileNameArchive from '../SetFileNameArchive/setFileNameArchive';
+import SetFileNameArchive from '../SetFileNameArchive/SetFileNameArchive';
 import ExcludeModelModal from '../DeleteModel/excludeModelModal';
 import EditModel from '../EditModal/EditModelsModal';
 import EditMinutesModal from '../EditModal/EditAtasModal';

--- a/src/routes.js
+++ b/src/routes.js
@@ -59,10 +59,10 @@ export function UserHeader() {
         <PrivateRoute path="/consulta-associados" component={ConsultaAssociados} type="administrador" />
         <PrivateRoute path="/consulta-atas-e-editais" component={ConsultasMinutes} type="administrador" />
         <PrivateRoute path="/associados-excluidos" component={AssociadosExcluidos} type="administrador" />
-        <PrivateRoute path="/ficha-associados" component={FichaAssociados} type="administrador" />
+        <PrivateRoute path="/ficha-associados" component={FichaAssociados} type="usuario" />
         <PrivateRoute path="/ficha-usuarios-externos" component={FichaUsuariosExternos} type="administrador" />
-        <PrivateRoute path="/ficha-atas" component={FichaMinutes} type="administrador" />
-        <PrivateRoute path="/ficha-noticia" component={FichaNoticia} type="administrador" />
+        <PrivateRoute path="/ficha-atas" component={FichaMinutes} type="usuario" />
+        <PrivateRoute path="/ficha-noticia" component={FichaNoticia} type="usuario" />
         <PrivateRoute path="/modulo-usuario" component={ModuloUsuarios} type="administrador" />
         <PrivateRoute path="/validar-socio" component={ValidarSocio} type="administrador" />
         <PrivateRoute path="/editais" component={Editais} type="administrador" />


### PR DESCRIPTION
fix: private routes '/ficha-associados', '/ficha-atas' and '/ficha-noticia' now accept acess from user, instead of only administrator.